### PR TITLE
feat: 🎸 add navigation to generators menu items

### DIFF
--- a/libs/generators/src/lib/generators/generators-menu/generators-menu.component.html
+++ b/libs/generators/src/lib/generators/generators-menu/generators-menu.component.html
@@ -1,7 +1,11 @@
 <mat-nav-list>
-    <div mat-list-item *ngFor="let menuItem of menuItems">
-        <a mat-button
-           class="menu-item" 
-           color="primary">{{menuItem}}</a>
-    </div>
+  <div mat-list-item *ngFor="let menuItem of menuItems">
+    <a
+      mat-button
+      class="menu-item"
+      color="primary"
+      (click)="navigate(menuItem)"
+      >{{ menuItem }}</a
+    >
+  </div>
 </mat-nav-list>

--- a/libs/generators/src/lib/generators/generators-menu/generators-menu.component.html
+++ b/libs/generators/src/lib/generators/generators-menu/generators-menu.component.html
@@ -4,7 +4,7 @@
       mat-button
       class="menu-item"
       color="primary"
-      (click)="navigate(menuItem)"
+      [routerLink]="['/generators', menuItem]"
       >{{ menuItem }}</a
     >
   </div>

--- a/libs/generators/src/lib/generators/generators-menu/generators-menu.component.scss
+++ b/libs/generators/src/lib/generators/generators-menu/generators-menu.component.scss
@@ -1,6 +1,7 @@
 :host {
-    .menu-item {
-        justify-content: left;
-        width: var(--menu-item-width);
-    }
+  .menu-item {
+    justify-content: left;
+    text-transform: capitalize;
+    width: var(--menu-item-width);
+  }
 }

--- a/libs/generators/src/lib/generators/generators-menu/generators-menu.component.spec.ts
+++ b/libs/generators/src/lib/generators/generators-menu/generators-menu.component.spec.ts
@@ -1,14 +1,22 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Router } from '@angular/router';
 
 import { GeneratorsMenuComponent } from './generators-menu.component';
 
 describe('GeneratorsMenuComponent', () => {
   let component: GeneratorsMenuComponent;
   let fixture: ComponentFixture<GeneratorsMenuComponent>;
+  let routerMock: any;
 
   beforeEach(async () => {
+    routerMock = {
+      navigate: () => null,
+    };
+
     await TestBed.configureTestingModule({
       imports: [GeneratorsMenuComponent],
+      providers: [{ provide: Router, useValue: routerMock }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(GeneratorsMenuComponent);
@@ -18,5 +26,25 @@ describe('GeneratorsMenuComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('navigate()', () => {
+    it('Should navigate to generator with provided generator name when function was called', () => {
+      jest.spyOn(routerMock, 'navigate');
+      component.navigate('generator_name_mock');
+      expect(routerMock.navigate).toHaveBeenCalledWith([
+        'generators',
+        'generator_name_mock',
+      ]);
+    });
+  });
+
+  describe('Menu Item', () => {
+    it('Should navigate to generator when menu item was clicked', () => {
+      jest.spyOn(component, 'navigate');
+      const menuItem = fixture.debugElement.query(By.css('.menu-item'));
+      menuItem.triggerEventHandler('click', null);
+      expect(component.navigate).toHaveBeenCalled();
+    });
   });
 });

--- a/libs/generators/src/lib/generators/generators-menu/generators-menu.component.spec.ts
+++ b/libs/generators/src/lib/generators/generators-menu/generators-menu.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { GeneratorsMenuComponent } from './generators-menu.component';
 
@@ -8,7 +9,7 @@ describe('GeneratorsMenuComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [GeneratorsMenuComponent],
+      imports: [GeneratorsMenuComponent, RouterTestingModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(GeneratorsMenuComponent);

--- a/libs/generators/src/lib/generators/generators-menu/generators-menu.component.spec.ts
+++ b/libs/generators/src/lib/generators/generators-menu/generators-menu.component.spec.ts
@@ -1,22 +1,14 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
-import { Router } from '@angular/router';
 
 import { GeneratorsMenuComponent } from './generators-menu.component';
 
 describe('GeneratorsMenuComponent', () => {
   let component: GeneratorsMenuComponent;
   let fixture: ComponentFixture<GeneratorsMenuComponent>;
-  let routerMock: any;
 
   beforeEach(async () => {
-    routerMock = {
-      navigate: () => null,
-    };
-
     await TestBed.configureTestingModule({
       imports: [GeneratorsMenuComponent],
-      providers: [{ provide: Router, useValue: routerMock }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(GeneratorsMenuComponent);
@@ -26,25 +18,5 @@ describe('GeneratorsMenuComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
-  });
-
-  describe('navigate()', () => {
-    it('Should navigate to generator with provided generator name when function was called', () => {
-      jest.spyOn(routerMock, 'navigate');
-      component.navigate('generator_name_mock');
-      expect(routerMock.navigate).toHaveBeenCalledWith([
-        'generators',
-        'generator_name_mock',
-      ]);
-    });
-  });
-
-  describe('Menu Item', () => {
-    it('Should navigate to generator when menu item was clicked', () => {
-      jest.spyOn(component, 'navigate');
-      const menuItem = fixture.debugElement.query(By.css('.menu-item'));
-      menuItem.triggerEventHandler('click', null);
-      expect(component.navigate).toHaveBeenCalled();
-    });
   });
 });

--- a/libs/generators/src/lib/generators/generators-menu/generators-menu.component.ts
+++ b/libs/generators/src/lib/generators/generators-menu/generators-menu.component.ts
@@ -1,23 +1,24 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatListModule } from '@angular/material/list';
 import { MatSidenavModule } from '@angular/material/sidenav';
-import { Router } from '@angular/router';
+import { RouterLink } from '@angular/router';
 
 @Component({
   selector: 'cli-generators-menu',
   standalone: true,
-  imports: [CommonModule, MatListModule, MatSidenavModule, MatButtonModule],
+  imports: [
+    CommonModule,
+    MatListModule,
+    MatSidenavModule,
+    MatButtonModule,
+    RouterLink,
+  ],
   templateUrl: './generators-menu.component.html',
   styleUrls: ['./generators-menu.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class GeneratorsMenuComponent {
-  public readonly router = inject(Router);
   public menuItems = ['component', 'directive', 'module', 'pipe'];
-
-  navigate(generatorName: string): void {
-    this.router.navigate(['generators', generatorName]);
-  }
 }

--- a/libs/generators/src/lib/generators/generators-menu/generators-menu.component.ts
+++ b/libs/generators/src/lib/generators/generators-menu/generators-menu.component.ts
@@ -1,8 +1,9 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatListModule } from '@angular/material/list';
 import { MatSidenavModule } from '@angular/material/sidenav';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'cli-generators-menu',
@@ -13,5 +14,10 @@ import { MatSidenavModule } from '@angular/material/sidenav';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class GeneratorsMenuComponent {
-  public menuItems = ['Component', 'Directive', 'Module', 'Pipe'];
+  public readonly router = inject(Router);
+  public menuItems = ['component', 'directive', 'module', 'pipe'];
+
+  navigate(generatorName: string): void {
+    this.router.navigate(['generators', generatorName]);
+  }
 }

--- a/libs/generators/src/lib/generators/generators.component.spec.ts
+++ b/libs/generators/src/lib/generators/generators.component.spec.ts
@@ -1,5 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { GeneratorsComponent } from './generators.component';
 
@@ -9,7 +10,7 @@ describe('GeneratorsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [GeneratorsComponent, NoopAnimationsModule],
+      imports: [GeneratorsComponent, NoopAnimationsModule, RouterTestingModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(GeneratorsComponent);


### PR DESCRIPTION
add navigation to generators menu item so each generator will navigate to his generator

✅ Closes: 48

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: [CONTRIBUTING.md](CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

there is no navigation

Issue Number: 48

## What is the new behavior?

clicking on menu item will navigate to relevant generator

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
