### PR TITLE
feat: home component

### DIFF
--- a/apps/cli-gui/src/app/app.component.html
+++ b/apps/cli-gui/src/app/app.component.html
@@ -12,6 +12,15 @@
         </mat-option>
       </mat-select>
     </div>
+    <button
+      class="home-button"
+      mat-icon-button
+      aria-label="Home"
+      [disabled]="!core.currentWorkspacePath"
+      routerLink="/"
+    >
+      <mat-icon>home</mat-icon>
+    </button>
   </mat-toolbar>
   <router-outlet></router-outlet>
 </ng-container>

--- a/apps/cli-gui/src/app/app.component.html
+++ b/apps/cli-gui/src/app/app.component.html
@@ -13,12 +13,5 @@
       </mat-select>
     </div>
   </mat-toolbar>
-  <mat-sidenav-container class="sidenav">
-    <mat-sidenav opened="true" mode="side">
-      <cli-menu [menuItems]="menuItems"></cli-menu>
-    </mat-sidenav>
-    <mat-sidenav-content class="content">
-      <router-outlet></router-outlet>
-    </mat-sidenav-content>
-  </mat-sidenav-container>
+  <router-outlet></router-outlet>
 </ng-container>

--- a/apps/cli-gui/src/app/app.component.scss
+++ b/apps/cli-gui/src/app/app.component.scss
@@ -13,4 +13,8 @@
     width: 50px;
     height: 50px;
   }
+
+  .home-button {
+    margin-inline-start: auto;
+  }
 }

--- a/apps/cli-gui/src/app/app.component.scss
+++ b/apps/cli-gui/src/app/app.component.scss
@@ -4,15 +4,6 @@
   height: 100%;
 }
 
-.content {
-  display: flex;
-  flex-direction: column;
-}
-
-.sidenav {
-  flex: 1;
-}
-
 .header {
   display: flex;
   align-items: center;

--- a/apps/cli-gui/src/app/app.component.ts
+++ b/apps/cli-gui/src/app/app.component.ts
@@ -1,5 +1,7 @@
 import { AsyncPipe, NgForOf, NgIf } from '@angular/common';
 import { Component } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
 import { MatSelectModule } from '@angular/material/select';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { Title } from '@angular/platform-browser';
@@ -23,6 +25,8 @@ import { CoreService } from './core/core.service';
     NgForOf,
     RouterLink,
     MatToolbarModule,
+    MatIconModule,
+    MatButtonModule,
   ],
   selector: 'cli-root',
   templateUrl: './app.component.html',

--- a/apps/cli-gui/src/app/app.component.ts
+++ b/apps/cli-gui/src/app/app.component.ts
@@ -1,8 +1,6 @@
 import { AsyncPipe, NgForOf, NgIf } from '@angular/common';
 import { Component } from '@angular/core';
-import { MatListModule } from '@angular/material/list';
 import { MatSelectModule } from '@angular/material/select';
-import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { Title } from '@angular/platform-browser';
 import {
@@ -11,10 +9,8 @@ import {
   RouterLink,
   RouterOutlet,
 } from '@angular/router';
-import { MenuComponent } from '@angular-cli-gui/ui';
 import { delay, filter, map, startWith } from 'rxjs';
 
-import { MAIN_MENU_ITEMS } from './app.consts';
 import { CoreService } from './core/core.service';
 
 @Component({
@@ -25,10 +21,7 @@ import { CoreService } from './core/core.service';
     RouterOutlet,
     MatSelectModule,
     NgForOf,
-    MatSidenavModule,
-    MatListModule,
     RouterLink,
-    MenuComponent,
     MatToolbarModule,
   ],
   selector: 'cli-root',
@@ -43,8 +36,6 @@ export class AppComponent {
     delay(0),
     map(() => this.title.getTitle())
   );
-
-  menuItems = MAIN_MENU_ITEMS;
 
   constructor(
     readonly core: CoreService,

--- a/apps/cli-gui/src/app/app.routes.ts
+++ b/apps/cli-gui/src/app/app.routes.ts
@@ -1,12 +1,13 @@
 import { Routes } from '@angular/router';
 
+import { currentWorkspaceGuard } from './guards/current-workspace.guard';
 
 export const APP_ROUTES: Routes = [
   {
     path: '',
     title: 'Home',
-    // canActivate: [currentWorkspaceGuard],
-    loadChildren: () => import('./home/home.routes').then((m) => m.HOME_ROUTES),
+    canActivate: [currentWorkspaceGuard()],
+    loadChildren: () => import('./home/home.routes'),
   },
   {
     path: 'workspace-manager',

--- a/apps/cli-gui/src/app/app.routes.ts
+++ b/apps/cli-gui/src/app/app.routes.ts
@@ -7,31 +7,7 @@ export const APP_ROUTES: Routes = [
     path: '',
     title: 'Home',
     canActivate: [currentWorkspaceGuard],
-    children: [
-      {
-        path: '',
-        redirectTo: 'generators',
-        pathMatch: 'full',
-      },
-      {
-        path: 'generators',
-        loadChildren: () => import('./generators/generators.routes'),
-      },
-      {
-        path: 'configuration',
-        loadComponent: () =>
-          import('@angular-cli-gui/configuration').then(
-            (m) => m.ConfigurationComponent
-          ),
-      },
-      {
-        path: 'executors',
-        loadComponent: () =>
-          import('@angular-cli-gui/executors').then(
-            (m) => m.ExecutorsComponent
-          ),
-      },
-    ],
+    loadChildren: () => import('./home/home.routes').then((m) => m.HOME_ROUTES),
   },
   {
     path: 'workspace-manager',

--- a/apps/cli-gui/src/app/app.routes.ts
+++ b/apps/cli-gui/src/app/app.routes.ts
@@ -6,7 +6,7 @@ export const APP_ROUTES: Routes = [
   {
     path: '',
     title: 'Home',
-    canActivate: [currentWorkspaceGuard()],
+    canActivate: [currentWorkspaceGuard],
     loadChildren: () => import('./home/home.routes'),
   },
   {

--- a/apps/cli-gui/src/app/app.routes.ts
+++ b/apps/cli-gui/src/app/app.routes.ts
@@ -1,12 +1,11 @@
 import { Routes } from '@angular/router';
 
-import { currentWorkspaceGuard } from './guards/current-workspace.guard';
 
 export const APP_ROUTES: Routes = [
   {
     path: '',
     title: 'Home',
-    canActivate: [currentWorkspaceGuard],
+    // canActivate: [currentWorkspaceGuard],
     loadChildren: () => import('./home/home.routes').then((m) => m.HOME_ROUTES),
   },
   {

--- a/apps/cli-gui/src/app/core/core.service.ts
+++ b/apps/cli-gui/src/app/core/core.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { CURRENT_WORKSPACE_PATH } from '@angular-cli-gui/shared/data';
 import { BehaviorSubject } from 'rxjs';
 
 export interface CoreState {
@@ -15,10 +16,12 @@ export class CoreService {
 
   readonly coreState$ = this.coreStateSubject$.asObservable();
 
-  // constructor() {}
-
   update(state: Partial<CoreState>): void {
     this.coreState = { ...this.coreState, ...state };
     this.coreStateSubject$.next(this.coreState);
+  }
+
+  get currentWorkspacePath(): string | null {
+    return sessionStorage.getItem(CURRENT_WORKSPACE_PATH);
   }
 }

--- a/apps/cli-gui/src/app/guards/current-workspace.guard.ts
+++ b/apps/cli-gui/src/app/guards/current-workspace.guard.ts
@@ -21,15 +21,14 @@ export const currentWorkspaceGuard = (): Observable<boolean | UrlTree> => {
   const core = inject(CoreService);
   const retrySubject = new Subject<void>();
   const projectNames$ = http.get<string[]>('/api/workspace/project-names');
-  const currentWorkspacePath = sessionStorage.getItem(CURRENT_WORKSPACE_PATH);
   const connectWorkspace$ = http.post<void>('/api/workspace/connect', {
-    path: currentWorkspacePath,
+    path: core.currentWorkspacePath,
   });
   const fallbackUrl$: Observable<UrlTree> = of(
     router.parseUrl('workspace-manager/connect-workspace')
   );
 
-  return !currentWorkspacePath
+  return !core.currentWorkspacePath
     ? fallbackUrl$
     : connectWorkspace$.pipe(
         switchMap(() =>

--- a/apps/cli-gui/src/app/home/home.component.html
+++ b/apps/cli-gui/src/app/home/home.component.html
@@ -1,0 +1,8 @@
+<mat-sidenav-container class="sidenav">
+  <mat-sidenav opened="true" mode="side">
+    <cli-menu [menuItems]="menuItems"></cli-menu>
+  </mat-sidenav>
+  <mat-sidenav-content class="content">
+    <router-outlet></router-outlet>
+  </mat-sidenav-content>
+</mat-sidenav-container>

--- a/apps/cli-gui/src/app/home/home.component.scss
+++ b/apps/cli-gui/src/app/home/home.component.scss
@@ -1,0 +1,13 @@
+:host {
+  flex: 1;
+  display: flex;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+}
+
+.sidenav {
+  flex: 1;
+}

--- a/apps/cli-gui/src/app/home/home.component.spec.ts
+++ b/apps/cli-gui/src/app/home/home.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { HomeComponent } from './home.component';
+
+describe('HomeComponent', () => {
+  let component: HomeComponent;
+  let fixture: ComponentFixture<HomeComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HomeComponent, RouterTestingModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HomeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/apps/cli-gui/src/app/home/home.component.spec.ts
+++ b/apps/cli-gui/src/app/home/home.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { HomeComponent } from './home.component';
@@ -9,7 +10,7 @@ describe('HomeComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HomeComponent, RouterTestingModule],
+      imports: [HomeComponent, RouterTestingModule, NoopAnimationsModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(HomeComponent);

--- a/apps/cli-gui/src/app/home/home.component.ts
+++ b/apps/cli-gui/src/app/home/home.component.ts
@@ -1,0 +1,18 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { MatSidenavModule } from '@angular/material/sidenav';
+import { RouterOutlet } from '@angular/router';
+import { MenuComponent } from '@angular-cli-gui/ui';
+
+import { MAIN_MENU_ITEMS } from '../app.consts';
+
+@Component({
+  selector: 'cli-home',
+  standalone: true,
+  imports: [MatSidenavModule, MenuComponent, RouterOutlet],
+  templateUrl: './home.component.html',
+  styleUrls: ['./home.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class HomeComponent {
+  menuItems = MAIN_MENU_ITEMS;
+}

--- a/apps/cli-gui/src/app/home/home.component.ts
+++ b/apps/cli-gui/src/app/home/home.component.ts
@@ -3,7 +3,7 @@ import { MatSidenavModule } from '@angular/material/sidenav';
 import { RouterOutlet } from '@angular/router';
 import { MenuComponent } from '@angular-cli-gui/ui';
 
-import { MAIN_MENU_ITEMS } from '../app.consts';
+import { HOME_MENU_ITEMS } from './home.consts';
 
 @Component({
   selector: 'cli-home',
@@ -14,5 +14,5 @@ import { MAIN_MENU_ITEMS } from '../app.consts';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class HomeComponent {
-  menuItems = MAIN_MENU_ITEMS;
+  menuItems = HOME_MENU_ITEMS;
 }

--- a/apps/cli-gui/src/app/home/home.consts.ts
+++ b/apps/cli-gui/src/app/home/home.consts.ts
@@ -1,6 +1,6 @@
 import { MenuItem } from '@angular-cli-gui/ui';
 
-export const MAIN_MENU_ITEMS: MenuItem[] = [
+export const HOME_MENU_ITEMS: MenuItem[] = [
   {
     url: '/generators',
     displayName: 'Generators',

--- a/apps/cli-gui/src/app/home/home.routes.ts
+++ b/apps/cli-gui/src/app/home/home.routes.ts
@@ -1,0 +1,36 @@
+import { Routes } from '@angular/router';
+
+import { HomeComponent } from './home.component';
+
+export const HOME_ROUTES: Routes = [
+  {
+    path: '',
+    component: HomeComponent,
+    title: 'Home',
+    children: [
+      {
+        path: '',
+        redirectTo: 'generators',
+        pathMatch: 'full',
+      },
+      {
+        path: 'generators',
+        loadChildren: () => import('../generators/generators.routes'),
+      },
+      {
+        path: 'configuration',
+        loadComponent: () =>
+          import('@angular-cli-gui/configuration').then(
+            (m) => m.ConfigurationComponent
+          ),
+      },
+      {
+        path: 'executors',
+        loadComponent: () =>
+          import('@angular-cli-gui/executors').then(
+            (m) => m.ExecutorsComponent
+          ),
+      },
+    ],
+  },
+];

--- a/apps/cli-gui/src/app/home/home.routes.ts
+++ b/apps/cli-gui/src/app/home/home.routes.ts
@@ -2,7 +2,7 @@ import { Routes } from '@angular/router';
 
 import { HomeComponent } from './home.component';
 
-export const HOME_ROUTES: Routes = [
+const HOME_ROUTES: Routes = [
   {
     path: '',
     component: HomeComponent,
@@ -34,3 +34,5 @@ export const HOME_ROUTES: Routes = [
     ],
   },
 ];
+
+export default HOME_ROUTES;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: [CONTRIBUTING.md](CONTRIBUTING.md#commit-message-format)
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently, we have a sidenav on the workspace-manager too.

Issue Number: N/A

## What is the new behavior?

This PR adds a "home" component in which all routes are children of this component, this way only "home" routes have a sidenav.

Add a "home" button on the header that is enabled only if there's a current workspace.

Workspace manager:

<img width="983" alt="image" src="https://user-images.githubusercontent.com/1301334/222959486-a4325333-375c-407b-a1c2-166b0c975a58.png">

Generators (in the next PR I will make the inner menu only icons)

<img width="984" alt="image" src="https://user-images.githubusercontent.com/1301334/222959538-9748c043-dfcf-4992-ad59-1dfa289d9dc7.png">

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
