### PR TITLE
feat: 🎸 async executors on be

### DIFF
--- a/apps/cli-daemon/src/app/app.module.ts
+++ b/apps/cli-daemon/src/app/app.module.ts
@@ -2,6 +2,7 @@ import { Global, Module } from '@nestjs/common';
 
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { ExecutorsModule } from './executors/executors.module';
 import { GeneratorsModule } from './generators/generators.module';
 import { SessionService } from './session/session.service';
 import { WorkspaceModule } from './workspace/workspace.module';
@@ -9,7 +10,12 @@ import { WorkspaceManagerModule } from './workspace-manager/workspace-manager.mo
 
 @Global()
 @Module({
-  imports: [WorkspaceModule, GeneratorsModule, WorkspaceManagerModule],
+  imports: [
+    WorkspaceModule,
+    GeneratorsModule,
+    WorkspaceManagerModule,
+    ExecutorsModule,
+  ],
   controllers: [AppController],
   providers: [AppService, SessionService],
   exports: [SessionService],

--- a/apps/cli-daemon/src/app/executors/child-process.ts
+++ b/apps/cli-daemon/src/app/executors/child-process.ts
@@ -1,0 +1,42 @@
+import { ChildProcessWithoutNullStreams } from 'node:child_process';
+
+import { TaskStatus } from '@angular-cli-gui/shared/data';
+import { Logger } from '@nestjs/common';
+
+import { StringBuffer } from './string-buffer';
+import { spawnedProcessCommandLine } from './utils';
+
+const STD_OUT_BUFFER_SIZE = 100;
+const STD_ERR_BUFFER_SIZE = 20;
+
+export class ChildProcess {
+  private readonly logger = new Logger(
+    `Child process "${spawnedProcessCommandLine(this.spawnedProcess)}"`
+  );
+  private readonly stdOutBuffer = new StringBuffer(STD_OUT_BUFFER_SIZE);
+  private readonly stdErrBuffer = new StringBuffer(STD_ERR_BUFFER_SIZE);
+  private exitCode?: number | null;
+
+  get status(): TaskStatus {
+    return {
+      stdOut: this.stdOutBuffer.data,
+      stdErr: this.stdErrBuffer.data,
+      isRunning: this.exitCode === undefined,
+      exitCode: this.exitCode,
+    };
+  }
+
+  constructor(readonly spawnedProcess: ChildProcessWithoutNullStreams) {
+    this.logger.verbose(`Spawned with PID: ${spawnedProcess.pid}`);
+    spawnedProcess.stdout.on('data', (data: Buffer) =>
+      this.stdOutBuffer.add(data)
+    );
+    spawnedProcess.stderr.on('data', (data: Buffer) =>
+      this.stdErrBuffer.add(data)
+    );
+    spawnedProcess.on('close', (code) => {
+      this.exitCode = code;
+      this.logger.verbose(`Terminated with code ${code}`);
+    });
+  }
+}

--- a/apps/cli-daemon/src/app/executors/child-processes.ts
+++ b/apps/cli-daemon/src/app/executors/child-processes.ts
@@ -1,0 +1,13 @@
+import { ChildProcessWithoutNullStreams } from 'node:child_process';
+
+import { ChildProcess } from './child-process';
+
+export class ChildProcesses extends Map<number, ChildProcess> {
+  add(spawnedProcess: ChildProcessWithoutNullStreams): void {
+    if (!spawnedProcess.pid) {
+      return;
+    }
+
+    this.set(spawnedProcess.pid, new ChildProcess(spawnedProcess));
+  }
+}

--- a/apps/cli-daemon/src/app/executors/executors.controller.spec.ts
+++ b/apps/cli-daemon/src/app/executors/executors.controller.spec.ts
@@ -1,0 +1,25 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { createExecutorsServiceMock } from '../../../testing';
+
+import { ExecutorsController } from './executors.controller';
+import { ExecutorsService } from './executors.service';
+
+describe('ExecutorsController', () => {
+  let controller: ExecutorsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ExecutorsController],
+      providers: [
+        { provide: ExecutorsService, useValue: createExecutorsServiceMock() },
+      ],
+    }).compile();
+
+    controller = module.get<ExecutorsController>(ExecutorsController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/apps/cli-daemon/src/app/executors/executors.controller.ts
+++ b/apps/cli-daemon/src/app/executors/executors.controller.ts
@@ -1,0 +1,65 @@
+import {
+  Command,
+  KillDto,
+  RunTaskResponse,
+  Task,
+  TaskStatus,
+} from '@angular-cli-gui/shared/data';
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Post,
+  Query,
+} from '@nestjs/common';
+
+import { ExecutorsService } from './executors.service';
+
+@Controller('executors')
+export class ExecutorsController {
+  constructor(private readonly executorsService: ExecutorsService) {}
+
+  @Post()
+  async run(@Body() commandDto: Command): Promise<RunTaskResponse> {
+    const command: string = commandDto.command;
+    const args = this.readArgsFromDto(commandDto);
+    const pid = await this.executorsService.execAsync([command].concat(args));
+
+    return { pid };
+  }
+
+  @Get('status')
+  getTaskStatus(@Query('pid') pid: number): TaskStatus {
+    if (!pid) {
+      throw new BadRequestException('PID was not provided');
+    }
+
+    return this.executorsService.readTaskStatus(pid);
+  }
+
+  @Delete()
+  killTask(@Body() killDto: KillDto): void {
+    this.executorsService.killTask(killDto.pid);
+  }
+
+  private readArgsFromDto(commandDto: Command): string[] {
+    const args: string[] = [];
+
+    for (const key in commandDto) {
+      if (key === 'command') {
+        continue;
+      }
+
+      args.push(`--${key}`, commandDto[key]?.toString());
+    }
+
+    return args;
+  }
+
+  @Get()
+  readAllTasks(): Task[] {
+    return this.executorsService.readAllTasks();
+  }
+}

--- a/apps/cli-daemon/src/app/executors/executors.module.ts
+++ b/apps/cli-daemon/src/app/executors/executors.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+
+import { ExecutorsController } from './executors.controller';
+import { ExecutorsService } from './executors.service';
+
+@Module({
+  controllers: [ExecutorsController],
+  providers: [ExecutorsService],
+  exports: [ExecutorsService],
+})
+export class ExecutorsModule {}

--- a/apps/cli-daemon/src/app/executors/executors.service.spec.ts
+++ b/apps/cli-daemon/src/app/executors/executors.service.spec.ts
@@ -1,0 +1,25 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { createSessionServiceMock } from '../../../testing';
+import { SessionService } from '../session/session.service';
+
+import { ExecutorsService } from './executors.service';
+
+describe('ExecutorsService', () => {
+  let service: ExecutorsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ExecutorsService,
+        { provide: SessionService, useValue: createSessionServiceMock() },
+      ],
+    }).compile();
+
+    service = module.get<ExecutorsService>(ExecutorsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/apps/cli-daemon/src/app/executors/executors.service.ts
+++ b/apps/cli-daemon/src/app/executors/executors.service.ts
@@ -1,0 +1,117 @@
+import {
+  ChildProcessWithoutNullStreams,
+  execSync,
+  spawn,
+} from 'node:child_process';
+import { resolve as pathResolve } from 'node:path';
+import process from 'node:process';
+
+import { Task, TaskStatus } from '@angular-cli-gui/shared/data';
+import {
+  Global,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+
+import { SessionService } from '../session/session.service';
+
+import { ChildProcesses } from './child-processes';
+import { spawnedProcessCommandLine } from './utils';
+
+const NG = 'npx ng';
+
+@Global()
+@Injectable()
+export class ExecutorsService {
+  private readonly logger = new Logger(ExecutorsService.name);
+  private childProcesses = new ChildProcesses();
+
+  constructor(private readonly sessionService: SessionService) {
+    process.on('SIGINT', () => this.destroy());
+    process.on('SIGTERM', () => this.destroy());
+  }
+
+  async execAsync(args: string[]): Promise<number> {
+    try {
+      const childProcess = await this.childProcessSpawn(args);
+      this.childProcesses.add(childProcess);
+
+      return childProcess.pid as number;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (err: any) {
+      this.logger.error(err.message);
+      throw new InternalServerErrorException(err.message);
+    }
+  }
+
+  readTaskStatus(pid: number): TaskStatus {
+    const childProcess = this.childProcesses.get(pid);
+
+    if (!childProcess) {
+      throw new NotFoundException(`Process with pid: ${pid} was not found`);
+    }
+
+    return childProcess.status;
+  }
+
+  killTask(pid: number): void {
+    const childProcess = this.childProcesses.get(pid);
+
+    if (!childProcess) {
+      throw new NotFoundException(`Process with pid: ${pid} was not found`);
+    }
+
+    this.kill(pid);
+  }
+
+  readAllTasks(): Task[] {
+    const tasks: Task[] = [];
+
+    for (const [pid, childProcess] of this.childProcesses.entries()) {
+      const { isRunning, exitCode } = childProcess.status;
+      const commandLine = spawnedProcessCommandLine(
+        childProcess.spawnedProcess
+      );
+      tasks.push({ pid, isRunning, exitCode, commandLine });
+    }
+
+    return tasks;
+  }
+
+  private destroy(): void {
+    this.logger.log('Application destroy hook');
+  }
+
+  private childProcessSpawn(
+    args: string[]
+  ): Promise<ChildProcessWithoutNullStreams> {
+    return new Promise((resolve, reject) => {
+      const childProcess = spawn(NG, args, {
+        cwd: pathResolve(this.sessionService.cwd),
+        env: process.env,
+        shell: true,
+      });
+
+      childProcess.on('error', (err) => reject(err));
+
+      if (childProcess.pid) {
+        resolve(childProcess);
+      }
+    });
+  }
+
+  private kill(pid: number): void {
+    switch (process.platform) {
+      case 'win32':
+        execSync(`taskkill /pid ${pid} /T /F`);
+        break;
+      case 'darwin':
+        throw new Error('Not yet implemented');
+        break;
+      default:
+        throw new Error('Not yet implemented');
+    }
+  }
+}

--- a/apps/cli-daemon/src/app/executors/string-buffer.ts
+++ b/apps/cli-daemon/src/app/executors/string-buffer.ts
@@ -1,0 +1,34 @@
+import { TerminalRecord } from '@angular-cli-gui/shared/data';
+
+import { stringToArray } from '../utils';
+
+export class StringBuffer {
+  private _data: TerminalRecord[] = [];
+  private counter = 1;
+
+  get data(): TerminalRecord[] {
+    return this._data.slice(0);
+  }
+
+  constructor(private readonly bufferSize?: number) {}
+
+  add(data: Buffer): void {
+    const dataStrings = stringToArray(data.toString('utf8'));
+
+    this._data = this._data.concat(
+      dataStrings.map((s) => ({
+        id: this.counter++,
+        timestamp: Date.now(),
+        content: s,
+      }))
+    );
+
+    if (this.bufferSize && this._data.length > this.bufferSize) {
+      this._data.splice(0, this._data.length - this.bufferSize);
+    }
+  }
+
+  clear(): void {
+    this._data = [];
+  }
+}

--- a/apps/cli-daemon/src/app/executors/utils/index.ts
+++ b/apps/cli-daemon/src/app/executors/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './spawned-process-cmd-line';

--- a/apps/cli-daemon/src/app/executors/utils/spawned-process-cmd-line.ts
+++ b/apps/cli-daemon/src/app/executors/utils/spawned-process-cmd-line.ts
@@ -1,0 +1,10 @@
+import { ChildProcessWithoutNullStreams } from 'child_process';
+
+export function spawnedProcessCommandLine(
+  spawnedProcess: ChildProcessWithoutNullStreams
+): string {
+  return spawnedProcess.spawnargs[spawnedProcess.spawnargs.length - 1]
+    .replace(/"/gi, '')
+    .replace('npx', '')
+    .trim();
+}

--- a/apps/cli-daemon/src/app/utils/string-to-array.ts
+++ b/apps/cli-daemon/src/app/utils/string-to-array.ts
@@ -1,3 +1,3 @@
 export function stringToArray(str: string): string[] {
-  return str.split('\n').filter((s) => !!s?.length);
+  return str.split('\n').filter((s) => !!s?.trim().length);
 }

--- a/apps/cli-daemon/testing/executors-service.mock.ts
+++ b/apps/cli-daemon/testing/executors-service.mock.ts
@@ -1,0 +1,11 @@
+import { ExecutorsService } from '../src/app/executors/executors.service';
+
+type ExecutorsServiceMock = Partial<Record<keyof ExecutorsService, jest.Mock>>;
+export function createExecutorsServiceMock(): ExecutorsServiceMock {
+  return {
+    execAsync: jest.fn(),
+    readTaskStatus: jest.fn(),
+    killTask: jest.fn(),
+    readAllTasks: jest.fn(),
+  };
+}

--- a/apps/cli-daemon/testing/index.ts
+++ b/apps/cli-daemon/testing/index.ts
@@ -1,1 +1,2 @@
 export * from './session-service.mock';
+export * from './executors-service.mock';

--- a/libs/shared/data/src/index.ts
+++ b/libs/shared/data/src/index.ts
@@ -3,3 +3,4 @@ export * from './lib/generate-component-args.interface';
 export * from './lib/directory.interface';
 export * from './lib/storage-keys.consts';
 export * from './lib/workspace';
+export * from './lib/executors';

--- a/libs/shared/data/src/lib/executors/command.ts
+++ b/libs/shared/data/src/lib/executors/command.ts
@@ -1,0 +1,5 @@
+import { AngularCommand } from './commands';
+
+export interface Command extends Record<string, string | number | boolean> {
+  command: AngularCommand;
+}

--- a/libs/shared/data/src/lib/executors/commands.ts
+++ b/libs/shared/data/src/lib/executors/commands.ts
@@ -1,0 +1,2 @@
+export const COMMANDS = ['build', 'lint', 'serve', 'test'] as const;
+export type AngularCommand = (typeof COMMANDS)[number];

--- a/libs/shared/data/src/lib/executors/index.ts
+++ b/libs/shared/data/src/lib/executors/index.ts
@@ -1,0 +1,7 @@
+export * from './run-task-response';
+export * from './task-status';
+export * from './commands';
+export * from './command';
+export * from './terminal-record';
+export * from './kill-dto';
+export * from './task';

--- a/libs/shared/data/src/lib/executors/kill-dto.ts
+++ b/libs/shared/data/src/lib/executors/kill-dto.ts
@@ -1,0 +1,3 @@
+export interface KillDto {
+  pid: number;
+}

--- a/libs/shared/data/src/lib/executors/run-task-response.ts
+++ b/libs/shared/data/src/lib/executors/run-task-response.ts
@@ -1,0 +1,3 @@
+export interface RunTaskResponse {
+  pid: number;
+}

--- a/libs/shared/data/src/lib/executors/task-status.ts
+++ b/libs/shared/data/src/lib/executors/task-status.ts
@@ -1,0 +1,8 @@
+import { TerminalRecord } from './terminal-record';
+
+export interface TaskStatus {
+  stdOut: TerminalRecord[];
+  stdErr: TerminalRecord[];
+  isRunning: boolean;
+  exitCode?: number | null;
+}

--- a/libs/shared/data/src/lib/executors/task.ts
+++ b/libs/shared/data/src/lib/executors/task.ts
@@ -1,0 +1,6 @@
+export interface Task {
+  pid: number;
+  isRunning: boolean;
+  exitCode?: number | null;
+  commandLine: string;
+}

--- a/libs/shared/data/src/lib/executors/terminal-record.ts
+++ b/libs/shared/data/src/lib/executors/terminal-record.ts
@@ -1,0 +1,5 @@
+export interface TerminalRecord {
+  id: number;
+  timestamp: number;
+  content: string;
+}


### PR DESCRIPTION
## PR Type

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

##Asynchronous tasks for executors API

- POST /executors with "command" and args dictionary in the body. Returns PID of the started task
- GET /executors/status?pid=<PID> Returns the task status and output. It can be used for polling to fill the "terminal" window on FE.
- GET /executors Returns list of tasks with their brief status information (something like ps -aux)
- DELETE /executors with { pid: <PID> } in the body. Stops the task. Works on win only for now, need to work on it for Mac and Linux.
